### PR TITLE
Added performance benchmark.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,22 @@ console.log(evil.reduce(dumbsum)) => 15.299999999999999
 console.log(add(evil)) => 15.3
 ```
 
+## Performance
+
+The performance benchmark tesll you how much slower `add` is compared to dumb addition. Run it using:
+
+```bash
+$ npm run benchmark
+```
+
+Here are some results (OS X 10.9.4, 2 GHz Core i7, 8GB DDR3 1600Mhz RAM):
+
+```bash
+add x 1,506,573 ops/sec ±1.40% (98 runs sampled)
+native x 25,749,229 ops/sec ±3.91% (84 runs sampled)
+Native is ~17.1 times faster
+```
+
 ## License
 
 The MIT License (MIT)

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,38 @@
+var Benchmark = require('benchmark'),
+  add = require('./');
+
+
+var testData = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+
+
+var addCustom = require('./');
+
+
+var addNative = function(p) {
+  var result = 0;
+  for (var i=0; i<testData.length; ++i) {
+    result += testData[i];
+  }
+  return result;
+};
+
+
+
+// add tests
+new Benchmark.Suite().add('add', {
+  fn: function() {
+    return addCustom(testData);
+  }
+})
+.add('native', {
+  fn: function() {
+    return addNative(testData);
+  }
+})
+.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+.on('complete', function() {
+  console.log("Native is ~" + (this[1].hz / this[0].hz).toFixed(1) + " times faster");
+})
+.run();

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "**/.*",
     "node_modules",
     "bower_components",
-    "test.js"
+    "test.js",
+    "benchmark.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A cross-browser, numerically stable algorithm to add floats accurately",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "benchmark": "node benchmark.js"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,8 @@
     "analysis"
   ],
   "devDependencies": {
-    "tape": "2.x.x"
+    "tape": "2.x.x",
+    "benchmark": "~1.0.0"
   },
   "testling": {
     "files": "test.js",


### PR DESCRIPTION
I wanted to know what the performance impact was so I added this in. I've added my results to the README.

The `Math.` functions are likely expensive compared to the rest of the code. I was able to massively speed up [`fast-levenshtein`](http://github.com/hiddentao/fast-levenshtein) by expanding `Math.min()` into manual code. Perhaps the same can be done here. We'll never match native but I think we can get closer.
