### PR TITLE
Massive speed-up by switching to params

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ var add = require('add')
 
 console.log(evil.reduce(dumbsum)) => 15.299999999999999
 
-console.log(add(evil)) => 15.3
+console.log(add.apply(null, evil)) => 15.3
 ```
 
 ## Performance
@@ -32,10 +32,10 @@ $ npm run benchmark
 Here are some results (OS X 10.9.4, 2 GHz Core i7, 8GB DDR3 1600Mhz RAM):
 
 ```bash
-add-precise x 1,400,712 ops/sec ±3.31% (89 runs sampled)
-add-dumb x 24,268,034 ops/sec ±3.96% (80 runs sampled)
-native x 94,957,251 ops/sec ±2.94% (85 runs sampled)
-native is ~67.8 times faster than add-precise
+add-precise x 13,043,885 ops/sec ±2.90% (91 runs sampled)
+add-dumb x 11,763,414 ops/sec ±1.89% (92 runs sampled)
+native x 91,023,425 ops/sec ±3.52% (84 runs sampled)
+native is ~7.0 times faster than add-precise
 ```
 
 ## License

--- a/benchmark.js
+++ b/benchmark.js
@@ -8,7 +8,8 @@ var testData = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3,
 var addCustom = require('./');
 
 
-var addNative = function(p) {
+var addNative = function() {
+  var p = arguments;
   var result = 0;
   for (var i=0; i<testData.length; ++i) {
     result += testData[i];
@@ -21,12 +22,12 @@ var addNative = function(p) {
 // add tests
 new Benchmark.Suite().add('add-precise', {
   fn: function() {
-    return addCustom(testData);
+    return addCustom.apply(testData);
   }
 })
 .add('add-dumb', {
   fn: function() {
-    return addNative(testData);
+    return addNative.apply(testData);
   }
 })
 .add('native', {

--- a/index.js
+++ b/index.js
@@ -155,7 +155,8 @@
     return sum
   }
 
-  function accSum(p) {
+  function accSum() {
+    var p = arguments;
 
     // Zero length array, or all values are zeros
     if(p.length === 0 || maxAbs(p) === 0) {

--- a/test.js
+++ b/test.js
@@ -27,15 +27,15 @@ test('accumulate', function (t) {
   t.plan(5)
 
 
-  t.equal(algorithm([1,2,3,4]), 10, 'Integer sum should work')
+  t.equal(algorithm(1,2,3,4), 10, 'Integer sum should work')
 
 
   t.equal(algorithm.dumbSum(badVector), 15.299999999999999, 'Inaccurate summation using naive method')
 
-  t.equal(algorithm(badVector), 15.3, 'Rump-Ogita-Oishi summation of insidious sum')
+  t.equal(algorithm.apply(null, badVector), 15.3, 'Rump-Ogita-Oishi summation of insidious sum')
 
-  t.equal(algorithm([0, 0, 0]), 0, 'Rump-Ogita-Oishi summation of zero array')
+  t.equal(algorithm(0, 0, 0), 0, 'Rump-Ogita-Oishi summation of zero array')
 
-  t.equal(algorithm([]), 0, 'Rump-Ogita-Oishi summation of empty array')
+  t.equal(algorithm(), 0, 'Rump-Ogita-Oishi summation of empty array')
 })
 


### PR DESCRIPTION
An ~12x speed-up by switching from using an array parameter to a parameter list, still allowing us to pass in an array of values using `.apply()`. 

As long as we stick to well-known optimization principles regarding the use of the `arguments` array ([see this](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments)) we should be ok. 

I'm almost thinking I've done something wrong here, it can't be this much faster! would appreciate your input.
